### PR TITLE
rayコードの修正。

### DIFF
--- a/Takochu/ui/EditorWindow.cs
+++ b/Takochu/ui/EditorWindow.cs
@@ -1715,44 +1715,103 @@ namespace Takochu.ui
             Debug.WriteLine("camera ray direction: " + ray.Direction);
         }
 
+        /// <summary>
+        /// SMG座標系での回転行列の取得。
+        /// </summary>
+        /// <param name="rad">軸回転</param>
+        /// <returns>回転行列(3次元)</returns>
+        private Matrix3 getRotMatrix3SmgCoordX(Vector3 rad)
+        {
+            return new Matrix3(
+                new Vector3(1.0f, 0.0f, 0.0f),
+                new Vector3(0.0f, (float)Math.Cos(rad.X), -(float)Math.Sin(rad.X)),
+                new Vector3(0.0f, (float)Math.Sin(rad.X), (float)Math.Cos(rad.X)));
+        }
+        /// <summary>
+        /// SMG座標系での回転行列の取得。
+        /// </summary>
+        /// <param name="rad">軸回転</param>
+        /// <returns>回転行列(3次元)</returns>
+        private Matrix3 GetRotMatrix3SmgCoordY(Vector3 rad)
+        {
+            return new Matrix3(
+                new Vector3((float)Math.Cos(rad.Y), 0.0f, (float)Math.Sin(rad.Y)),
+                new Vector3(0f, 1f, 0f),
+                new Vector3(-(float)Math.Sin(rad.Y), 0.0f, (float)Math.Cos(rad.Y)));
+        }
+        /// <summary>
+        /// SMG座標系での回転行列の取得。
+        /// </summary>
+        /// <param name="rad">軸回転</param>
+        /// <returns>回転行列(3次元)</returns>
+        private Matrix3 GetRotMatrix3SmgCoordZ(Vector3 rad)
+        {
+            return new Matrix3(
+                new Vector3((float)Math.Cos(rad.Z), -(float)Math.Sin(rad.Z), 0.0f),
+                new Vector3((float)Math.Sin(rad.Z), (float)Math.Cos(rad.Z), 0.0f),
+                new Vector3(0.0f, 0.0f, 1.0f));
+        }
+
+        /// <summary>
+        /// SMG座標軸でのカメラのグローバル回転行列の取得。
+        /// </summary>
+        /// <returns></returns>
+        private Matrix3 GetCamRotMatrix3SMGCoord() {
+            // SMG座標での回転。
+            Vector3 rotateRad = new Vector3(0f, _camRotation.X, -_camRotation.Y);
+            return GetRotMatrix3SmgCoordZ(rotateRad) * GetRotMatrix3SmgCoordY(rotateRad);
+        }
+
+        /// <summary>
+        /// カメラのローカル座標でのレイの方向を計算します。
+        /// </summary>
+        /// <param name="mousePos"></param>
+        /// <returns></returns>
+        private Vector3 CalculateVectorFromCursorPos(Point mousePos) {
+            // このプロジェクトのGL.Vertex3()座標はSMG座標互換です。
+            // そのため、右手 上y、 手前xでレンダリングされます。
+            // また、マウス座標は左上が原点であり、FOVはrad(70度)VFovです。
+            // 軸は、下記のようになっているようです。
+            //  X Y Z :エディタ座標
+            //  _ X-Y :内部カメラ回転
+
+            // SMG座標に変換後計算をします。
+            // 画面中央を基準値にとした座標の割合を計算し、回転軸に関連付ける。
+            // -2は2pxの縁が存在するため。
+            int dotOffset = 0;
+            var editorHeight = glLevelView.Size.Height - dotOffset;
+            var editorWidth = glLevelView.Size.Width - dotOffset;
+            double aspectRatio = (double)editorWidth / (double)editorHeight;
+            double hWidth = editorWidth / 2d;
+            double hHeight = editorHeight / 2d;
+            Vector3d mouseToRotateD = new Vector3d(
+                0d, 
+                -((hWidth - (double)mousePos.X) / hWidth),
+                (hHeight - (double)mousePos.Y) / hHeight);
+            // ドット値をラジアンに変換 + 画面座標の補正をします。
+            double vHarfFov = (double)FOV / 2d;
+            double vHarfFovTan = Math.Tan(vHarfFov);
+            double hHarfFovTan = Math.Tan(vHarfFov) * aspectRatio;
+            double hHarfFov = Math.Atan(hHarfFovTan);
+
+            mouseToRotateD.Y = Math.Atan(mouseToRotateD.Y * hHarfFovTan);
+            // Y軸の回転分倍率補正を掛ける。
+            mouseToRotateD.Z = Math.Atan(mouseToRotateD.Z * vHarfFovTan * Math.Abs(Math.Cos(mouseToRotateD.Y)));
+
+            // 基準となる正面方向のベクトル。
+            Vector3 ray = new Vector3(-1f, 0f, 0f);
+
+            ray *= GetRotMatrix3SmgCoordZ((Vector3)mouseToRotateD) * GetRotMatrix3SmgCoordY((Vector3)mouseToRotateD);
+
+            return Vector3.Normalize(ray); 
+        }
+
         private Ray ScreenToRay(Point mousePos)//カメラZ軸非対応(Incompatible :: cam Z rotate.)
-        { 
-            // このプロジェクトのGL座標はSMG座標互換です。
-            // そのため、右手 上y、 手前xでレンダリングされる模様。
-
-            //namespace System(cppLang & memo)
-            //GL系の座標で計算してSMG系の座標に変換しています。（vector2のX座標がSMGのZ座標のため）
-
-            Vector2 mousePosRayRad = new Vector2();
-            float k_FOV_RadPerDot = FOV / glLevelView.Height;
-            float k_FOV_harf = FOV / 2;
-            //(mouse move)y rad
-            mousePosRayRad.Y = k_FOV_harf - (k_FOV_RadPerDot * mousePos.Y);
-            //x rad
-            mousePosRayRad.X = ((k_FOV_harf * _aspectRatio) - ((k_FOV_RadPerDot) * mousePos.X));
-
-            //convert.
-            Vector3 rotateRad = new Vector3(-_camRotation.Y, -_camRotation.X, 0f);
-
-            //x rotate only.(view y rotate)
-            rotateRad += new Vector3(mousePosRayRad.Y,
-                                     0f,
-                                     0f
-                                     );
-
-            //yz rotate add.(view x rotate)
-            Vector3 ray = new Vector3((float)((Math.Sin(rotateRad.Y) * Math.Cos(rotateRad.X)) + (Math.Cos(rotateRad.Y) * Math.Sin(mousePosRayRad.X))),
-                                      (float)((Math.Sin(rotateRad.X) * (Math.Cos(mousePosRayRad.X)))),
-                                      (float)((Math.Cos(rotateRad.Y) * Math.Cos(rotateRad.X)) + (Math.Sin(-rotateRad.Y) * Math.Sin(mousePosRayRad.X)))
-                                      );
-
-            ray = new Vector3(-ray.Z, ray.Y, ray.X);
-
-            ray = Vector3.Normalize(ray);
-
-            ray = new Vector3(1f, 0f, 0f);
-
-            return new Ray(_camTarget, ray);
+        {
+            var toGlobal = GetCamRotMatrix3SMGCoord();
+            // SMGグローバル座標でのカメラの収束点の計算
+            Vector3 camConvergence = new Vector3(_camDistance, 0.0f, 0.0f) * toGlobal;
+            return new Ray(_camTarget + camConvergence, CalculateVectorFromCursorPos(mousePos) * toGlobal);
         }
 
         private void lightsTreeView_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)

--- a/Takochu/ui/EditorWindow.cs
+++ b/Takochu/ui/EditorWindow.cs
@@ -1056,7 +1056,7 @@ namespace Takochu.ui
                         var objTrueRot = obj.mParentZone.mGalaxy.Get_Rot_GlobalOffset(obj.mParentZone.ZoneName);
                         var positionWithZoneRotation = calc.RotateTransAffine.GetPositionAfterRotation(obj.mTruePosition, objTrueRot, calc.RotateTransAffine.TargetVector.All);
 
-                        Vector3 v0 = Vector3.Add(positionWithZoneRotation,triangle.V0.Xyz)*10000f;
+                        Vector3 v0 = Vector3.Add(positionWithZoneRotation, triangle.V0.Xyz) * 10000f;
                         Vector3 v1 = Vector3.Add(positionWithZoneRotation, triangle.V1.Xyz) * 10000f;
                         Vector3 v2 = Vector3.Add(positionWithZoneRotation, triangle.V2.Xyz) * 10000f;
                         Vector3 normal_vector = Vector3.Normalize(Vector3.Cross(v1 - v0, v2 - v0));
@@ -1094,8 +1094,6 @@ namespace Takochu.ui
                     // if条件: どの三角面とも交差していない場合にif内部に入る(何もしない)
                     if (nearest_hitpoint_distance == float.MaxValue)
                     {
-                        
-
                         MessageBox.Show("交点なし");
 
                         Debug.WriteLine("DEBUG★: the position you clicked is " + nearest_hitpoint_position.ToString());
@@ -1103,6 +1101,8 @@ namespace Takochu.ui
                     }
                     else 
                     {
+                        MessageBox.Show("交点あり");
+
                         textBox1.Text = "☆DEBUG☆: the position you clicked is " + nearest_hitpoint_position.ToString();
                         Debug.WriteLine("☆DEBUG☆: the position you clicked is " + nearest_hitpoint_position.ToString());
                     } 
@@ -1716,7 +1716,10 @@ namespace Takochu.ui
         }
 
         private Ray ScreenToRay(Point mousePos)//カメラZ軸非対応(Incompatible :: cam Z rotate.)
-        {
+        { 
+            // このプロジェクトのGL座標はSMG座標互換です。
+            // そのため、右手 上y、 手前xでレンダリングされる模様。
+
             //namespace System(cppLang & memo)
             //GL系の座標で計算してSMG系の座標に変換しています。（vector2のX座標がSMGのZ座標のため）
 
@@ -1747,6 +1750,7 @@ namespace Takochu.ui
 
             ray = Vector3.Normalize(ray);
 
+            ray = new Vector3(1f, 0f, 0f);
 
             return new Ray(_camTarget, ray);
         }


### PR DESCRIPTION
Ray.Originをカメラの回転原点ではなくカメラの収束点になるように変更。
Ray.Direction算出用の計算の大幅な変更。
- 計算ミス低減のため回転行列を使用した回転。
- 共通処理の関数化。
- 座標軸の基準をSMG系に変更。(補足: OpenTKの設定で完全互換となっている模様。)
- 未実装だった画面補正処理の実装。

その他:
rayテストに使用していたラインを、カメラの回転原点からrayの終点に変更。
 これにより、中心からマウスの座標(rayの終点)となり座標がわかりやすくなっています。
rayを使用した交点処理のrayの原点はray.Originを使用しているようだったのでray.Originの変更による問題が起こる可能性は低いです。
ただ、交点処理用のモデルメッシュの修正がまだですので、テストはできていません。